### PR TITLE
Handling single special license

### DIFF
--- a/how_to_update.md
+++ b/how_to_update.md
@@ -1,4 +1,4 @@
-# Note for me:
+# Note for me
 
 How to update the project:
 

--- a/src/ros_license_toolkit/license_tag.py
+++ b/src/ros_license_toolkit/license_tag.py
@@ -50,12 +50,11 @@ def to_spdx_license_tag(license_name: str) -> str:
 
 def _eval_glob(glob_str: str, pkg_path: str) -> Set[str]:
     """Evaluate a glob string and return a set of matching relative paths."""
-    paths = set()
-    for fpath in glob(os.path.join(pkg_path, glob_str), recursive=True):
-        if not os.path.isfile(fpath):
-            continue
-        paths.add(os.path.relpath(fpath, pkg_path))
-    return paths
+    return {
+        os.path.relpath(fpath, pkg_path)
+        for fpath in glob(os.path.join(pkg_path, glob_str), recursive=True)
+        if os.path.isfile(fpath)
+    }
 
 
 class LicenseTag:

--- a/src/ros_license_toolkit/license_tag.py
+++ b/src/ros_license_toolkit/license_tag.py
@@ -129,8 +129,6 @@ class LicenseTag:
 
     def make_this_the_main_license(self, other_licenses: List["LicenseTag"]):
         """Make this the main license for the package."""
-
-        # Handle source files
         assert not self.has_source_files(), \
             "This must not have a source-files, yet."
         assert self.source_files_str == "**", \
@@ -142,15 +140,3 @@ class LicenseTag:
                 continue
             source_files -= other_license.source_files
         self._source_files = source_files
-
-        # Handle license text file
-        if self.has_license_text_file():
-            return
-        potential_license_files = [
-            file
-            for file in os.listdir(self.package_path)
-            if "LICENSE" in file or "COPYING" in file
-        ]
-        assert len(potential_license_files) == 1, \
-            "There must be exactly one potential license file."
-        self.license_text_file = potential_license_files[0]

--- a/src/ros_license_toolkit/license_tag.py
+++ b/src/ros_license_toolkit/license_tag.py
@@ -129,6 +129,8 @@ class LicenseTag:
 
     def make_this_the_main_license(self, other_licenses: List["LicenseTag"]):
         """Make this the main license for the package."""
+
+        # Handle source files
         assert not self.has_source_files(), \
             "This must not have a source-files, yet."
         assert self.source_files_str == "**", \
@@ -140,3 +142,15 @@ class LicenseTag:
                 continue
             source_files -= other_license.source_files
         self._source_files = source_files
+
+        # Handle license text file
+        if self.has_license_text_file():
+            return
+        potential_license_files = [
+            file
+            for file in os.listdir(self.package_path)
+            if "LICENSE" in file or "COPYING" in file
+        ]
+        assert len(potential_license_files) == 1, \
+            "There must be exactly one potential license file."
+        self.license_text_file = potential_license_files[0]

--- a/test/_test_data/copyright_file_contents/test_pkg_unknown_license
+++ b/test/_test_data/copyright_file_contents/test_pkg_unknown_license
@@ -1,0 +1,12 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Source: https://fake.git
+Upstream-Name: test_pkg_unknown_license
+
+Files:
+ **
+Copyright: (c) 2017 - 2018
+License: my own fancy license 1.0
+ My own fancy license content !! (c) 2017 - 2018 
+ 🌴
+
+

--- a/test/_test_data/test_pkg_unknown_license/my_LICENSE
+++ b/test/_test_data/test_pkg_unknown_license/my_LICENSE
@@ -1,0 +1,2 @@
+My own fancy license content !! (c) 2017 - 2018 
+🌴

--- a/test/systemtest/test_copyright.py
+++ b/test/systemtest/test_copyright.py
@@ -28,7 +28,8 @@ TEST_PACKAGES_COPYRIGHT_FILE = [
     "test_pkg_has_code_of_different_license_and_tag",
     "test_pkg_spdx_name",
     "test_pkg_spdx_tag",
-    "test_pkg_with_license_and_file"
+    "test_pkg_with_license_and_file",
+    "test_pkg_unknown_license"
 ]
 
 
@@ -70,7 +71,6 @@ def test_get_copyright_file_contents():
         pkg_path = os.path.join(TEST_DATA_FOLDER, pkg_name)
         pkg = get_packages_in_path(pkg_path)[0]
         copyright_file_content = pkg.get_copyright_file_contents()
-        print(copyright_file_content)
         with open(os.path.join(
                 TEST_DATA_FOLDER,
                 "copyright_file_contents",


### PR DESCRIPTION
This will recognize a license text in the package root, even for unknown licenses