### PR TITLE
Pins Python version in Github action to 3.11 and bumps tag to 1.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: boschresearch/ros_license_toolkit@1.1.5
+      - uses: boschresearch/ros_license_toolkit@1.2.3
 ```
 
 ## State of Development

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: Install Python
       uses: actions/setup-python@v3
       with:
-        python-version: '3.x'
+        python-version: '3.11'
     - name: Install package
       run: pip install $GITHUB_ACTION_PATH
       shell: bash


### PR DESCRIPTION
The Readme suggested to use the action with tag 1.1.5, however the action was only introduced in 1.2.0 and therefore the Readme snippet leads to this error:
```
Download action repository 'actions/checkout@v3' (SHA:f43a0e5ff2bd294095638e18286ca9a3d1956744)
Download action repository 'boschresearch/ros_license_toolkit@1.1.5' (SHA:74fb93c22d7b37be1bbb274bcabd0f951b45dcfa)
Error: Can't find 'action.yml', 'action.yaml' or 'Dockerfile' for action 'boschresearch/ros_license_toolkit@1.1.5'.
```

When I bumped it to >=1.2.0 I got issues building Scancode Toolkit:
```
      intbitset/intbitset.c: In function ‘__Pyx_PyIndex_AsSsize_t’:
      intbitset/intbitset.c:18453:45: error: ‘PyLongObject’ {aka ‘struct _longobject’} has no member named ‘ob_digit’
      18453 |     const digit* digits = ((PyLongObject*)b)->ob_digit;
            |                                             ^~
      error: command '/usr/bin/gcc' failed with exit code 1
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for intbitset
```
The full error is for example [here](https://github.com/matthias-mayr/skiros2/actions/runs/7586682063/job/20665381131), but it's a [known issue with Scantoolkit](https://github.com/nexB/scancode-toolkit/issues/3585) not being compatible with Python 3.12 that is pulled by the action's `3.x` statement.

In 843bfac I pinned the Python version in the action to 3.11 being the newest Scantoolkit is compatible with.

I ran this in my fork an now the action [works for me](https://github.com/matthias-mayr/skiros2/actions/runs/7586890440/job/20666076538).

In e749eac I bumped the action tag in the Readme to 1.2.3, assuming that this PR would make you do a new release. 