### PR TITLE
Feature: add check for every license has a matching tag

### DIFF
--- a/src/ros_license_toolkit/checks.py
+++ b/src/ros_license_toolkit/checks.py
@@ -355,7 +355,7 @@ class LicenseFilesReferencedCheck(Check):
             if '../' in filename:
                 continue
             if license_text['detected_license_expression_spdx'] not in \
-                package.license_tags:
+               package.license_tags:
                 not_covered_texts[filename] = \
                     license_text['detected_license_expression_spdx']
         if not_covered_texts:

--- a/src/ros_license_toolkit/checks.py
+++ b/src/ros_license_toolkit/checks.py
@@ -356,7 +356,7 @@ class LicenseFilesReferencedCheck(Check):
         inofficial_covered_texts: Dict[str, List[str]] = {}
         for filename, license_text in package.found_license_texts.items():
             # skipping all declarations above the package
-            if not self._is_in_package(package, filename):
+            if not is_in_package(package, filename):
                 continue
             if 'detected_license_expression_spdx' in license_text and \
                license_text['detected_license_expression_spdx'] not in \
@@ -393,12 +393,13 @@ class LicenseFilesReferencedCheck(Check):
         else:
             self._success("All license declaration are referenced by a tag.")
 
-    def _is_in_package(self, package: Package, file: str) -> bool:
-        """Return TRUE if the file is underneath the absolute package path.
-        Return FALSE if file is located above package."""
-        parent = os.path.abspath(package.abspath)
-        child = os.path.abspath(package.abspath + '/' + file)
 
-        comm_parent = os.path.commonpath([parent])
-        comm_child_parent = os.path.commonpath([parent, child])
-        return comm_parent == comm_child_parent
+def is_in_package(package: Package, file: str) -> bool:
+    """Return TRUE if the file is underneath the absolute package path.
+    Return FALSE if file is located above package."""
+    parent = os.path.abspath(package.abspath)
+    child = os.path.abspath(package.abspath + '/' + file)
+
+    comm_parent = os.path.commonpath([parent])
+    comm_child_parent = os.path.commonpath([parent, child])
+    return comm_parent == comm_child_parent

--- a/src/ros_license_toolkit/checks.py
+++ b/src/ros_license_toolkit/checks.py
@@ -344,21 +344,52 @@ class LicenseFilesReferencedCheck(Check):
 
     def _check(self, package: Package):
         not_covered_texts: Dict[str, str] = {}
+        inofficial_covered_texts: Dict[str, List[str]] = {}
         for filename, license_text in package.found_license_texts.items():
             # skipping all declarations above the package
-            if '../' in filename:
+            if not self._is_in_package(package, filename):
                 continue
-            if license_text['detected_license_expression_spdx'] not in \
+            if 'detected_license_expression_spdx' in license_text and \
+               license_text['detected_license_expression_spdx'] not in \
                package.license_tags:
-                not_covered_texts[filename] = \
-                    license_text['detected_license_expression_spdx']
+                spdx_expression = license_text[
+                    'detected_license_expression_spdx']
+                inofficial_licenses = {
+                    lic_tag.id_from_license_text: key
+                    for key, lic_tag in package.license_tags.items()
+                    if lic_tag.id_from_license_text != ''}
+                if spdx_expression in inofficial_licenses:
+                    inofficial_covered_texts[filename] = \
+                        [spdx_expression,
+                         inofficial_licenses[spdx_expression]]
+                else:
+                    not_covered_texts[filename] = \
+                        spdx_expression
         if not_covered_texts:
             info_str = ''
-            info_str += 'The following license declarations are not' +\
-                ' mentioned by any tag. Check if they can be removed:\n' +\
+            info_str += 'The following license files are not' +\
+                ' mentioned by any tag:\n' +\
                 '\n'.join(
                     [f"  '{x[0]}' is of {x[1]}."
                      for x in not_covered_texts.items()])
+            self._failed(info_str)
+        elif inofficial_covered_texts:
+            info_str = ''
+            info_str += 'The following license files are not' +\
+                ' mentioned by any tag:\n' +\
+                '\n'.join(
+                    [f"  '{x[0]}' is of {x[1][0]} but its tag is {x[1][1]}."
+                     for x in inofficial_covered_texts.items()])
             self._warning(info_str)
         else:
             self._success("All license declaration are referenced by a tag.")
+
+    def _is_in_package(self, package: Package, file: str) -> bool:
+        """Return TRUE if the file is underneath the absolute package path.
+        Return FALSE if file is located above package."""
+        parent = os.path.abspath(package.abspath)
+        child = os.path.abspath(package.abspath + '/' + file)
+
+        comm_parent = os.path.commonpath([parent])
+        comm_child_parent = os.path.commonpath([parent, child])
+        return comm_parent == comm_child_parent

--- a/src/ros_license_toolkit/main.py
+++ b/src/ros_license_toolkit/main.py
@@ -27,7 +27,9 @@ from typing import Optional, Sequence
 from ros_license_toolkit.checks import (LicensesInCodeCheck,
                                         LicenseTagExistsCheck,
                                         LicenseTagIsInSpdxListCheck,
-                                        LicenseTextExistsCheck, Status)
+                                        LicenseTextExistsCheck, 
+                                        LicenseFilesReferencedCheck,
+                                        Status)
 from ros_license_toolkit.package import get_packages_in_path
 from ros_license_toolkit.ui_elements import (FAILURE_STR, SUCCESS_STR,
                                              WARNING_STR, Verbosity, major_sep,
@@ -134,7 +136,8 @@ def process_one_pkg(rll_print, package):
         LicenseTagExistsCheck(),
         LicenseTagIsInSpdxListCheck(),
         LicenseTextExistsCheck(),
-        LicensesInCodeCheck()]
+        LicensesInCodeCheck(),
+        LicenseFilesReferencedCheck()]
 
     for check in checks_to_perform:
         check.check(package)

--- a/src/ros_license_toolkit/main.py
+++ b/src/ros_license_toolkit/main.py
@@ -24,12 +24,11 @@ import sys
 import timeit
 from typing import Optional, Sequence
 
-from ros_license_toolkit.checks import (LicensesInCodeCheck,
+from ros_license_toolkit.checks import (LicenseFilesReferencedCheck,
+                                        LicensesInCodeCheck,
                                         LicenseTagExistsCheck,
                                         LicenseTagIsInSpdxListCheck,
-                                        LicenseTextExistsCheck, 
-                                        LicenseFilesReferencedCheck,
-                                        Status)
+                                        LicenseTextExistsCheck, Status)
 from ros_license_toolkit.package import get_packages_in_path
 from ros_license_toolkit.ui_elements import (FAILURE_STR, SUCCESS_STR,
                                              WARNING_STR, Verbosity, major_sep,

--- a/test/_test_data/test_pkg_too_many_license_files/LICENSE
+++ b/test/_test_data/test_pkg_too_many_license_files/LICENSE
@@ -1,0 +1,46 @@
+The Academic Free License
+ v. 2.0
+
+This Academic Free License (the "License") applies to any original work of authorship (the "Original Work") whose owner (the "Licensor") has placed the following notice immediately following the copyright notice for the Original Work:   
+Licensed under the Academic Free License version 2.0
+
+1) Grant of Copyright License. Licensor hereby grants You a world-wide, royalty-free, non-exclusive, perpetual, sublicenseable license to do the following: 
+a) to reproduce the Original Work in copies; 
+
+b) to prepare derivative works ("Derivative Works") based upon the Original Work; 
+
+c) to distribute copies of the Original Work and Derivative Works to the public; 
+
+d) to perform the Original Work publicly; and 
+
+e) to display the Original Work publicly.   
+
+2) Grant of Patent License. Licensor hereby grants You a world-wide, royalty-free, non-exclusive, perpetual, sublicenseable license, under patent claims owned or controlled by the Licensor that are embodied in the Original Work as furnished by the Licensor, to make, use, sell and offer for sale the Original Work and Derivative Works.  
+
+3) Grant of Source Code License. The term "Source Code" means the preferred form of the Original Work for making modifications to it and all available documentation describing how to modify the Original Work.  Licensor hereby agrees to provide a machine-readable copy of the Source Code of the Original Work along with each copy of the Original Work that Licensor distributes.  Licensor reserves the right to satisfy this obligation by placing a machine-readable copy of the Source Code in an information repository reasonably calculated to permit inexpensive and convenient access by You for as long as Licensor continues to distribute the Original Work, and by publishing the address of that information repository in a notice immediately following the copyright notice that applies to the Original Work.    
+
+4) Exclusions From License Grant. Neither the names of Licensor, nor the names of any contributors to the Original Work, nor any of their trademarks or service marks, may be used to endorse or promote products derived from this Original Work without express prior written permission of the Licensor.  Nothing in this License shall be deemed to grant any rights to trademarks, copyrights, patents, trade secrets or any other intellectual property of Licensor except as expressly stated herein.  No patent license is granted to make, use, sell or offer to sell embodiments of any patent claims other than the licensed claims defined in Section 2.  No right is granted to the trademarks of Licensor even if such marks are included in the Original Work.  Nothing in this License shall be interpreted to prohibit Licensor from licensing under different terms from this License any Original Work that Licensor otherwise would have a right to license.  
+
+5) This section intentionally omitted.  
+
+6) Attribution Rights. You must retain, in the Source Code of any Derivative Works that You create, all copyright, patent or trademark notices from the Source Code of the Original Work, as well as any notices of licensing and any descriptive text identified therein as an "Attribution Notice."  You must cause the Source Code for any Derivative Works that You create to carry a prominent Attribution Notice reasonably calculated to inform recipients that You have modified the Original Work.  
+
+7) Warranty of Provenance and Disclaimer of Warranty. Licensor warrants that the copyright in and to the Original Work and the patent rights granted herein by Licensor are owned by the Licensor or are sublicensed to You under the terms of this License with the permission of the contributor(s) of those copyrights and patent rights.  Except as expressly stated in the immediately proceeding sentence, the Original Work is provided under this License on an "AS IS" BASIS and WITHOUT WARRANTY, either express or implied, including, without limitation, the warranties of NON-INFRINGEMENT, MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY OF THE ORIGINAL WORK IS WITH YOU.  This DISCLAIMER OF WARRANTY constitutes an essential part of this License.  No license to Original Work is granted hereunder except under this disclaimer.  
+
+8) Limitation of Liability. Under no circumstances and under no legal theory, whether in tort (including negligence), contract, or otherwise, shall the Licensor be liable to any person for any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or the use of the Original Work including, without limitation, damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses.  This limitation of liability shall not apply to liability for death or personal injury resulting from Licensor's negligence to the extent applicable law prohibits such limitation.  Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so this exclusion and limitation may not apply to You.  
+
+9) Acceptance and Termination. If You distribute  copies of the Original Work or a Derivative Work, You must make a reasonable effort under the circumstances to obtain the express assent of recipients to the terms of this License.  Nothing else but this License (or another written agreement between Licensor and You) grants You permission to create Derivative Works based upon the Original Work or to exercise any of the rights granted in Section 1 herein, and any attempt to do so except under the terms of this License (or another written agreement between Licensor and You) is expressly prohibited by U.S. copyright law, the equivalent laws of other countries, and by international treaty.  Therefore, by exercising any of the rights granted to You in Section 1 herein, You indicate Your acceptance of this License and all of its terms and conditions.    
+
+10) Termination for Patent Action. This License shall terminate automatically and You may no longer exercise any of the rights granted to You by this License as of the date You commence an action, including a cross-claim or counterclaim, for patent infringement (i) against Licensor with respect to a patent applicable to software or (ii) against any entity with respect to a patent applicable to the Original Work (but excluding combinations of the Original Work with other software or hardware).    
+
+11) Jurisdiction, Venue and Governing Law. Any action or suit relating to this License may be brought only in the courts of a jurisdiction wherein the Licensor resides or in which Licensor conducts its primary business, and under the laws of that jurisdiction excluding its conflict-of-law provisions.  The application of the United Nations Convention on Contracts for the International Sale of Goods is expressly excluded.  Any use of the Original Work outside the scope of this License or after its termination shall be subject to the requirements and penalties of the U.S. Copyright Act, 17 U.S.C. � 101 et seq., the equivalent laws of other countries, and international treaty.  This section shall survive the termination of this License.  
+
+12) Attorneys Fees. In any action to enforce the terms of this License or seeking damages relating thereto, the prevailing party shall be entitled to recover its costs and expenses, including, without limitation, reasonable attorneys' fees and costs incurred in connection with such action, including any appeal of such action.  This section shall survive the termination of this License.  
+
+13) Miscellaneous. This License represents the complete agreement concerning the subject matter hereof.  If any provision of this License is held to be unenforceable, such provision shall be reformed only to the extent necessary to make it enforceable.    
+
+14) Definition of "You" in This License. "You" throughout this License, whether in upper or lower case, means an individual or a legal entity exercising rights under, and complying with all of the terms of, this License.  For legal entities, "You" includes any entity that controls, is controlled by, or is under common control with you.  For purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.   
+
+15) Right to Use. You may use the Original Work in all ways not otherwise restricted or conditioned by this License or by law, and Licensor promises not to interfere with or be responsible for such uses by You.    
+
+This license is Copyright (C) 2003 Lawrence E. Rosen.  All rights reserved.  Permission is hereby granted to copy and distribute this license without modification.  This license may not be modified without the express written permission of its copyright owner. 

--- a/test/_test_data/test_pkg_too_many_license_files/apl.LICENSE
+++ b/test/_test_data/test_pkg_too_many_license_files/apl.LICENSE
@@ -1,0 +1,203 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/test/_test_data/test_pkg_too_many_license_files/bsd.LICENSE
+++ b/test/_test_data/test_pkg_too_many_license_files/bsd.LICENSE
@@ -1,0 +1,11 @@
+Copyright 1995 Foo Bar
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/test/_test_data/test_pkg_too_many_license_files/package.xml
+++ b/test/_test_data/test_pkg_too_many_license_files/package.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>test_pkg_too_many_license_files</name>
+  <license file="LICENSE">AFL-2.0</license>
+</package>

--- a/test/systemtest/test_all_packages.py
+++ b/test/systemtest/test_all_packages.py
@@ -56,6 +56,7 @@ class TestAllPackages(unittest.TestCase):
         self.assertIn(b"test_pkg_one_correct_one_license_file_missing", stdout)
         self.assertIn(b"test_pkg_spdx_name", stdout)
         self.assertIn(b"test_pkg_spdx_tag", stdout)
+        self.assertIn(b"test_pkg_too_many_license_files", stdout)
         self.assertIn(b"test_pkg_unknown_license", stdout)
         self.assertIn(b"test_pkg_unknown_license_missing_file", stdout)
         self.assertIn(b"test_pkg_with_license_and_file", stdout)

--- a/test/systemtest/test_separate_pkgs.py
+++ b/test/systemtest/test_separate_pkgs.py
@@ -26,6 +26,8 @@ from ros_license_toolkit.main import main
 
 class TestPkgs(unittest.TestCase):
     """Test different test packages."""
+    # pylint: disable=too-many-public-methods
+    # Here it make sense to keep all tests in one place
 
     def test_deep_package_folder(self):
         """Call the linter on directories in three levels.
@@ -132,6 +134,15 @@ class TestPkgs(unittest.TestCase):
         with the SPDX tag."""
         self.assertEqual(os.EX_OK, main(
             ["test/_test_data/test_pkg_spdx_tag"]))
+
+    def test_pkg_too_many_license_files(self):
+        """"Test on a package with multiple License files that are not
+        declared by any tag and could therefore be removed."""
+        process, stdout = open_subprocess("test_pkg_too_many_license_files")
+        self.assertEqual(os.EX_OK, process.returncode)
+        self.assertIn(b"WARNING", stdout)
+        self.assertIn(b"bsd.LICENSE", stdout)
+        self.assertIn(b"apl.LICENSE", stdout)
 
     def test_pkg_unknown_license(self):
         """Test on a package with an unknown license declared in the

--- a/test/systemtest/test_separate_pkgs.py
+++ b/test/systemtest/test_separate_pkgs.py
@@ -143,6 +143,7 @@ class TestPkgs(unittest.TestCase):
         self.assertIn(b"WARNING", stdout)
         self.assertIn(b"bsd.LICENSE", stdout)
         self.assertIn(b"apl.LICENSE", stdout)
+        self.assertNotIn(b"../../../LICENSE", stdout)
 
     def test_pkg_unknown_license(self):
         """Test on a package with an unknown license declared in the

--- a/test/systemtest/test_separate_pkgs.py
+++ b/test/systemtest/test_separate_pkgs.py
@@ -139,8 +139,7 @@ class TestPkgs(unittest.TestCase):
         """"Test on a package with multiple License files that are not
         declared by any tag and could therefore be removed."""
         process, stdout = open_subprocess("test_pkg_too_many_license_files")
-        self.assertEqual(os.EX_OK, process.returncode)
-        self.assertIn(b"WARNING", stdout)
+        self.assertEqual(os.EX_DATAERR, process.returncode)
         self.assertIn(b"bsd.LICENSE", stdout)
         self.assertIn(b"apl.LICENSE", stdout)
         self.assertNotIn(b"../../../LICENSE", stdout)


### PR DESCRIPTION
Added check for not referenced license declarations.
Check only gives out warnings if anything is found.
To make sure only local package is checked, everything above the package location is ignored (There were problems with declarations that were found but are not part of package)
Also added test that checks for these warnings.